### PR TITLE
Refactoring - make 'FileEmailRepository' thread-safe

### DIFF
--- a/src/application/services/campaign_service.go
+++ b/src/application/services/campaign_service.go
@@ -5,7 +5,6 @@ import "btcRate/application"
 type IEmailRepository interface {
 	AddEmail(email string) error
 	GetAll() []string
-	Save() error
 }
 
 type IEmailClient interface {
@@ -29,11 +28,6 @@ func (c *CampaignService) Subscribe(email string) error {
 	}
 
 	err = c.emailRepository.AddEmail(email)
-	if err != nil {
-		return err
-	}
-
-	err = c.emailRepository.Save()
 	if err != nil {
 		return err
 	}

--- a/src/tests/campaign_service_test.go
+++ b/src/tests/campaign_service_test.go
@@ -7,13 +7,15 @@ import (
 	"btcRate/infrastructure/repositories"
 	"github.com/stretchr/testify/assert"
 	"os"
+	"sync"
 	"testing"
 )
 
 const storageFile = "artifacts/emails.json"
 
 func setup() *services.CampaignService {
-	emailRepo, _ := repositories.NewFileEmailRepository(storageFile)
+	mutex := &sync.RWMutex{}
+	emailRepo, _ := repositories.NewFileEmailRepository(storageFile, mutex)
 	emailValidator := &validators.EmailValidator{}
 	service := services.NewCampaignService(emailRepo, nil, emailValidator)
 

--- a/src/web/btc_uah_controller.go
+++ b/src/web/btc_uah_controller.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sendgrid/sendgrid-go"
 	"net/http"
 	"os"
+	"sync"
 )
 
 // @title GSES2 BTC application API
@@ -32,7 +33,9 @@ func newBtcUahController(emailStorageFile string, logStorageFile string) (*btcUa
 	supportedCurrency := "UAH"
 	supportedCoin := "BTC"
 
-	var emailRepository, err = repositories.NewFileEmailRepository(emailStorageFile)
+	emailMutex := &sync.RWMutex{}
+
+	var emailRepository, err = repositories.NewFileEmailRepository(emailStorageFile, emailMutex)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**Проблема:**
Репозиторій `FileEmailRepository` не є thread-safe. Він видає непередбачувані результати коли декілька потоків одночасно до нього звертаються.

**Рішення:**
Додати `RWMutex` до `FileEmailRepository` для забезпечення ексклюзивного Write доступу до сховища email'ів.